### PR TITLE
systemd service tuning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tps2388-init (2) stable; urgency=medium
+
+  * ensure i2c device is available before starting
+  * convert to oneshot removing logging of status information
+
+ -- Josua Mayer <josua@solid-run.com>  Thu, 09 Jan 2020 15:29:54 +0100
+
 tps2388-init (1) stable; urgency=low
 
   * Initial Release.

--- a/debian/rules
+++ b/debian/rules
@@ -3,3 +3,8 @@
 # main packaging script based on dh7 syntax
 %:
 	dh $@ --with systemd
+
+override_dh_auto_install:
+	dh_auto_install
+	mkdir -p $(CURDIR)/debian/tps2388-init/etc/modules-load.d
+	echo "i2c-dev" > $(CURDIR)/debian/tps2388-init/etc/modules-load.d/tps2388-init.conf

--- a/debian/tps2388-init.service
+++ b/debian/tps2388-init.service
@@ -3,7 +3,8 @@ Description=Initialize TPS2388 PoE Controller
 After=local-fs.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/sbin/tps2388-init
 
 [Install]

--- a/debian/tps2388-init.service
+++ b/debian/tps2388-init.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Initialize TPS2388 PoE Controller
 After=local-fs.target
+After=sys-devices-platform-soc-soc:internal\x2dregs-f1011000.i2c-i2c\x2d0-i2c\x2ddev-i2c\x2d0.device
+BindsTo=sys-devices-platform-soc-soc:internal\x2dregs-f1011000.i2c-i2c\x2d0-i2c\x2ddev-i2c\x2d0.device
 
 [Service]
 Type=oneshot

--- a/debian/tps2388-init.udev
+++ b/debian/tps2388-init.udev
@@ -1,0 +1,1 @@
+SUBSYSTEM=="i2c-dev", KERNEL=="i2c-0", TAG+="systemd"

--- a/main_auto.c
+++ b/main_auto.c
@@ -34,6 +34,19 @@ int main(int argc, char *argv[])
 		detectionPortEvents, classificationPortEvents,
 		pcutPortEvents, disconnectPortEvents, inrushPortEvents,
 		ilimPortEvents;
+	int opt;
+	int opt_monitor = 0;
+
+	while ((opt = getopt(argc, argv, "m")) != -1) {
+		switch (opt) {
+			case 'm':
+				opt_monitor = 1;
+				break;
+			default: /* '?' */
+				fprintf(stderr, "Usage: %s [-m]\n", argv[0]);
+				return 1;
+		}
+	}
 
 	linux_i2c_open_dev("/dev/i2c-0");
 
@@ -49,7 +62,7 @@ int main(int argc, char *argv[])
 
 	PSE_TPS238X_init(OPERATING_MODE_AUTO);
 
-	while(1)
+	while(opt_monitor)
 	{
 		sleep(10);
 


### PR DESCRIPTION
- convert to oneshot
- load i2c-dev module
- start service only after /dev/i2c-0 is available