### PR TITLE
limit systemd service to Clearfog GTR devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tps2388-init (3) stable; urgency=medium
+
+  * only start on Clearfog GTR devices
+
+ -- Josua Mayer <josua@solid-run.com>  Tue, 21 Jan 2020 18:15:46 +0100
+
 tps2388-init (2) stable; urgency=medium
 
   * ensure i2c device is available before starting

--- a/debian/tps2388-init.service
+++ b/debian/tps2388-init.service
@@ -8,6 +8,7 @@ BindsTo=sys-devices-platform-soc-soc:internal\x2dregs-f1011000.i2c-i2c\x2d0-i2c\
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/tps2388-init
+ExecCondition=grep "^SolidRun Clearfog GTR.*$" /proc/device-tree/model
 
 [Install]
 WantedBy=network.target


### PR DESCRIPTION
Since the PoE controller is not (yet) modeled in Device-Tree,
we have to rely on the model field for now.